### PR TITLE
Support for closing with Escape and a panel background color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Use `alt-g alt-d` to toggle the diff or configure it to your liking:
 ```
 '.editor':
   'cmd-g cmd-d': 'git-diff-details:toggle-git-diff-details'
+  'escape': 'git-diff-details:close-git-diff-details'
 ```
 
 ![git-diff-details](https://github.com/samu/git-diff-details/blob/master/demo.gif?raw=true)

--- a/keymaps/atom-git-diff-details.cson
+++ b/keymaps/atom-git-diff-details.cson
@@ -1,2 +1,3 @@
 '.editor':
   'alt-g alt-d': 'git-diff-details:toggle-git-diff-details'
+  'escape': 'git-diff-details:close-git-diff-details'

--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -45,6 +45,13 @@ module.exports = class AtomGitDiffDetailsView extends View
 
   toggleShowDiffDetails: ->
     @showDiffDetails = !@showDiffDetails
+    @updateDiffDetails()
+
+  closeDiffDetails: ->
+    @showDiffDetails = false
+    @updateDiffDetails()
+
+  updateDiffDetails: ->
     @diffDetailsDataManager.invalidatePreviousSelectedHunk()
     @updateCurrentRow()
     @updateDiffDetailsDisplay()

--- a/lib/housekeeping.coffee
+++ b/lib/housekeeping.coffee
@@ -13,6 +13,9 @@ module.exports = class Housekeeping extends Mixin
     @subscribeToCommand @editorView, 'git-diff-details:toggle-git-diff-details', =>
       @toggleShowDiffDetails()
 
+    @subscribeToCommand @editorView, 'git-diff-details:close-git-diff-details', =>
+      @closeDiffDetails()
+
     @subscribe @editorView, 'editor:will-be-removed', =>
       @cancelUpdate()
       @unsubscribe()

--- a/menus/atom-git-diff-details.cson
+++ b/menus/atom-git-diff-details.cson
@@ -5,6 +5,10 @@
       'label': 'Toggle atom-git-diff-details'
       'command': 'atom-git-diff-details:toggle'
     }
+    {
+      'label': 'Close atom-git-diff-details'
+      'command': 'atom-git-diff-details:close'
+    }
   ]
 'menu': [
   {
@@ -15,6 +19,10 @@
         {
           'label': 'Toggle'
           'command': 'atom-git-diff-details:toggle'
+        }
+        {
+          'label': 'Close'
+          'command': 'atom-git-diff-details:close'
         }
       ]
     ]

--- a/stylesheets/git-diff-details.less
+++ b/stylesheets/git-diff-details.less
@@ -1,6 +1,7 @@
 @import "ui-variables";
 
 .git-diff-details-outer {
+  background-color: @base-background-color;
   width: 100%;
 }
 


### PR DESCRIPTION
This adds support for closing the panel using the escape key rather than the default shortcut assigned to the plugin. It also adds a background color to the diff view using the default background color.

I tried to write a unit test, but no matter how I tried, I never got it to run properly (even with just the test cases that came with the package).