### PR TITLE
Update display panel to work with more ui/theme combination

### DIFF
--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -10,7 +10,7 @@ module.exports = class AtomGitDiffDetailsView extends View
   @content: ->
     @div class: "git-diff-details-outer", =>
       @div class: "git-diff-details-main-panel", outlet: "mainPanel", =>
-        @div class: "editor", outlet: "contents"
+        @div class: "editor git-diff-editor", outlet: "contents"
       @div class: "git-diff-details-button-panel", outlet: "buttonPanel", =>
         @button class: 'btn btn-primary inline-block-tight', click: "copy", 'Copy'
         @button class: 'btn btn-error inline-block-tight', click: "undo", 'Undo'

--- a/styles/git-diff-details.less
+++ b/styles/git-diff-details.less
@@ -2,14 +2,22 @@
 
 .git-diff-details-outer {
   background-color: @base-background-color;
+  outline: 2px solid @base-border-color;
+  // padding: 2px;
   width: 100%;
-}
+  min-width: 400px;
 
-.git-diff-details-main-panel {
-  outline: gray dotted 1px;
-  position: relative;
-}
+  .git-diff-details-main-panel {
+    position: relative;
 
-.git-diff-details-button-panel {
-  margin: 2px;
+    .editor.git-diff-editor {
+      background-color: @syntax-background-color;
+    }
+  }
+
+  .git-diff-details-button-panel {
+    text-align: right;
+    padding: 2px;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
The diff panel now renders appropriately in more color scheme + syntax theme combinations.

One Dark + Sepia
<img width="376" alt="before (one dark and sepia)" src="https://cloud.githubusercontent.com/assets/930039/13203588/45c1e77a-d881-11e5-9c53-8edadc2acf6c.png">
<img width="496" alt="after (one dark and sepia)" src="https://cloud.githubusercontent.com/assets/930039/13203607/84f0abac-d881-11e5-8346-af18a58ba3bb.png">

One Dark + Solarized Dark
<img width="485" alt="before (one dark and solarized dark)
" src="https://cloud.githubusercontent.com/assets/930039/13203590/4c73cd9a-d881-11e5-96f4-02957ea90a0e.png">
<img width="510" alt="after (one dark and solarized dark)" src="https://cloud.githubusercontent.com/assets/930039/13203624/c8d4306e-d881-11e5-8794-cecf3a547c4d.png">

One Light + Solarized Light
<img width="466" alt="before (one light and solarized light)" src="https://cloud.githubusercontent.com/assets/930039/13203630/ea2abfda-d881-11e5-8a0b-85778d56531d.png">
<img width="494" alt="after (one light and solarized light)" src="https://cloud.githubusercontent.com/assets/930039/13203636/f7e4a12c-d881-11e5-8b91-986b25911f9c.png">

One Light + Solarized Dark
<img width="431" alt="before one light and solarized dark" src="https://cloud.githubusercontent.com/assets/930039/13203640/1b9ad000-d882-11e5-8c2f-2a5d1f664ac7.png">
<img width="507" alt="after one light and solarized dark" src="https://cloud.githubusercontent.com/assets/930039/13203642/1ea5adec-d882-11e5-8321-d29e3fc0066e.png">

