### PR TITLE
undo: buffer#setTextInRange instead of #deleteRows + #insert

### DIFF
--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -75,8 +75,7 @@ module.exports = class AtomGitDiffDetailsView extends View
 
     if selectedHunk? and buffer = @editor.getBuffer()
       if selectedHunk.kind is "m"
-        buffer.deleteRows(selectedHunk.start - 1, selectedHunk.end - 1)
-        buffer.insert([selectedHunk.start - 1, 0], selectedHunk.oldString)
+        buffer.setTextInRange([[selectedHunk.start - 1, 0], [selectedHunk.end, 0]], selectedHunk.oldString)
       else
         buffer.insert([selectedHunk.start, 0], selectedHunk.oldString)
       @closeDiffDetails() unless atom.config.get('git-diff-details.keepViewToggled')


### PR DESCRIPTION
Currently the undo command creates two entries in Atom's undo stack, one for deleting the new string, another for inserting the old string.
This means that to undo an undo command the user has to hit cmd+z twice.
This change has the same behaviour (I believe) but with just one entry in the undo stack.

Thanks for the great package!