### PR TITLE
Escape HTML strings

### DIFF
--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -1,5 +1,6 @@
 {View} = require 'atom-space-pen-views'
 {Range, Point} = require 'atom'
+_ = require 'underscore-plus'
 DiffDetailsDataManager = require './data-manager'
 Housekeeping = require './housekeeping'
 
@@ -102,9 +103,9 @@ module.exports = class AtomGitDiffDetailsView extends View
       @editor.decorateMarker(@newLinesMarker, type: 'line', class: "git-diff-details-new")
 
   populate: (selectedHunk) ->
-    html = selectedHunk.oldString .split(/\r\n?|\n/g)
-                                  .map((line) -> line.replace(/\s/g, '&nbsp;'))
-                                  .map((line) -> "<div class='line git-diff-details-old'>#{line}</div>")
+    html = _.escape(selectedHunk.oldString).split(/\r\n?|\n/g)
+                                           .map((line) -> line.replace(/\s/g, '&nbsp;'))
+                                           .map((line) -> "<div class='line git-diff-details-old'>#{line}</div>")
     @contents.html(html)
 
   updateDiffDetailsDisplay: ->

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "atom": ">=1.6.0"
   },
   "dependencies": {
-    "mixto": "1.x",
     "atom-space-pen-views": "^2.0.3",
-    "fs-plus": "^2.0.0"
+    "fs-plus": "^2.0.0",
+    "mixto": "1.x",
+    "underscore-plus": "^1.6.6"
   }
 }


### PR DESCRIPTION
Contents are not displayed correctly when they include HTML strings like `</div>`.