### PR TITLE
Use Atom's TextEditor and its view to display old versions

### DIFF
--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -19,7 +19,7 @@ module.exports = class AtomGitDiffDetailsView extends View
     @preventFocusOut()
 
     @diffDetailsDataManager = new DiffDetailsDataManager()
-    @diffEditor = atom.workspace.buildTextEditor(lineNumberGutterVisible: false)
+    @diffEditor = atom.workspace.buildTextEditor(lineNumberGutterVisible: false, scrollPastEnd: false)
     diffEditorElement = atom.views.getView(@diffEditor)
     @contents.html(diffEditorElement)
 

--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -107,7 +107,10 @@ module.exports = class AtomGitDiffDetailsView extends View
     @oldBlockMarker = @editor.markBufferRange(range)
     @editor.decorateMarker(@oldBlockMarker, type: 'block', position: 'after', item: this)
 
-    @diffEditor.setGrammar(@getActiveTextEditor()?.getGrammar())
+    if atom.config.get('git-diff-details.enableSyntaxHighlighting')
+      @diffEditor.setGrammar(@getActiveTextEditor()?.getGrammar())
+    else
+      @diffEditor.setGrammar(@diffEditor.grammarRegistry.grammarForScopeName("text.plain"))
     @diffEditor.setText(selectedHunk.oldString.replace(/[\r\n]+$/g, ""))
     @oldLinesMarker = @decorateLines(@diffEditor, 0, selectedHunk.oldLines.length, "old")
 

--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -20,6 +20,8 @@ module.exports = class AtomGitDiffDetailsView extends View
 
     @diffDetailsDataManager = new DiffDetailsDataManager()
     @diffEditor = atom.workspace.buildTextEditor(lineNumberGutterVisible: false)
+    diffEditorElement = atom.views.getView(@diffEditor)
+    @contents.html(diffEditorElement)
 
     @showDiffDetails = false
     @lineDiffDetails = null
@@ -108,8 +110,6 @@ module.exports = class AtomGitDiffDetailsView extends View
     @diffEditor.setGrammar(@getActiveTextEditor()?.getGrammar())
     @diffEditor.setText(selectedHunk.oldString.replace(/[\r\n]+$/g, ""))
     @oldLinesMarker = @decorateLines(@diffEditor, 0, selectedHunk.oldLines.length, "old")
-    element = atom.views.getView(@diffEditor)
-    @contents.html(element)
 
   updateDiffDetailsDisplay: ->
     if @showDiffDetails

--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -90,6 +90,12 @@ module.exports = class AtomGitDiffDetailsView extends View
     @newLinesMarker?.destroy()
     @newLinesMarker = null
 
+  decorateLines: (editor, start, end, type) ->
+    range = new Range(new Point(start, 0), new Point(end, 0))
+    marker = editor.markBufferRange(range)
+    editor.decorateMarker(marker, type: 'line', class: "git-diff-details-#{type}")
+    marker
+
   attach: (selectedHunk) ->
     @destroyDecoration()
     range = new Range(new Point(selectedHunk.end - 1, 0), new Point(selectedHunk.end - 1, 0))
@@ -100,16 +106,12 @@ module.exports = class AtomGitDiffDetailsView extends View
       item: this
 
     unless selectedHunk.kind is "d"
-      range = new Range(new Point(selectedHunk.start - 1, 0), new Point(selectedHunk.end, 0))
-      @newLinesMarker = @editor.markBufferRange(range)
-      @editor.decorateMarker(@newLinesMarker, type: 'line', class: "git-diff-details-new")
+      @newLinesMarker = @decorateLines(@editor, selectedHunk.start - 1, selectedHunk.end, "new")
 
   populate: (selectedHunk) ->
     @diffEditor.setGrammar(@getActiveTextEditor()?.getGrammar())
     @diffEditor.setText(selectedHunk.oldString.replace(/[\r\n]+$/g, ""))
-    range = new Range(new Point(0, 0), new Point(selectedHunk.oldLines.length, 0))
-    @oldLinesMarker = @diffEditor.markBufferRange(range)
-    @diffEditor.decorateMarker(@oldLinesMarker, type: 'line', class: "git-diff-details-old")
+    @oldLinesMarker = @decorateLines(@diffEditor, 0, selectedHunk.oldLines.length, "old")
     element = atom.views.getView(@diffEditor)
     @contents.html(element)
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,6 +12,11 @@ module.exports =
       default: true
       title: "Keep view toggled when leaving a diff"
 
+    enableSyntaxHighlighting:
+      type: "boolean"
+      default: false
+      title: "Enable syntax highlighting in diff view"
+
   activate: ->
     atom.workspace.observeTextEditors (editor) ->
       new AtomGitDiffDetailsView(editor)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/samu/git-diff-details",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.6.0"
+    "atom": ">=1.7.0"
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",

--- a/styles/git-diff-details.atom-text-editor.less
+++ b/styles/git-diff-details.atom-text-editor.less
@@ -1,4 +1,5 @@
 @import "ui-variables";
+@import "syntax-variables";
 
 .git-diff-details-outer {
   background-color: @base-background-color;
@@ -17,22 +18,10 @@
 
 .line {
   &.git-diff-details-new {
-    background-color: rgba(162, 232, 120, 0.7) !important;
-    color: black !important;
-    span {
-      color: black !important;
-    }
-
-    .invisible-character {
-      opacity: 0;
-    }
+    background-color: fade(@syntax-color-added, 25%);
   }
 
   &.git-diff-details-old {
-    background-color: rgba(232, 120, 120, 0.7) !important;
-    color: black !important;
-    span {
-      color: black !important;
-    }
+    background-color: fade(@syntax-color-removed, 25%);
   }
 }

--- a/styles/git-diff-details.atom-text-editor.less
+++ b/styles/git-diff-details.atom-text-editor.less
@@ -18,10 +18,10 @@
 
 .line {
   &.git-diff-details-new {
-    background-color: fade(@syntax-color-added, 25%);
+    background-color: fade(@syntax-color-added, 25%) !important;
   }
 
   &.git-diff-details-old {
-    background-color: fade(@syntax-color-removed, 25%);
+    background-color: fade(@syntax-color-removed, 25%) !important;
   }
 }


### PR DESCRIPTION
Using Atom's `TextEditor` class and its view, we can do following things:

- Hard tabs are displayed with correct width. Fix #48.
- Syntax highlighting is enabled.
- Text is selectable (#30).

I am planning to implement word-by-word diffs, and this also makes highlighting words easier in the diff view via Decoration API.