### PR TITLE
Call invalidate if diffDetailsDataManager is defined #54

### DIFF
--- a/lib/git-diff-details-view.coffee
+++ b/lib/git-diff-details-view.coffee
@@ -44,7 +44,7 @@ module.exports = class AtomGitDiffDetailsView extends View
 
   notifyContentsModified: =>
     return if @editor.isDestroyed()
-    @diffDetailsDataManager.invalidate(@repositoryForPath(@editor.getPath()),
+    @diffDetailsDataManager?.invalidate(@repositoryForPath(@editor.getPath()),
                                        @editor.getPath(),
                                        @editor.getText())
     if @showDiffDetails


### PR DESCRIPTION
On my system ( win 10 ), the change above makes the diff show up. Could you please have a look?